### PR TITLE
Fix #32 - Explain the need for a Webhook.

### DIFF
--- a/docs/repo_webhook.md
+++ b/docs/repo_webhook.md
@@ -1,5 +1,18 @@
 ## Configuring webhook in a FIWARE GitHub repository
 
+According to the [mission statement](https://www.fiware.org/foundation/) of the
+FIWARE Foundation, the Foundation promotes FIWARE related assets across several
+locations, such as [fiware.org](http;//fiware,org),
+[ReadtheDocs](https://readthedocs.org/) and [GitHub](https://github.com/).
+
+To keep the message on GitHub focused, the Foundation restricts the main
+[github.com/FIWARE](https://github.com/fiware/) account to assets (such as Data
+Models, Specifications and Tutorials) owned by the Foundation itself. For the
+Generic Enablers, mirror copies of the source code are hosted under a separate
+[github.com/FIWARE-GEs](https://github.com/fiware-ges) account in order to
+maintain infrastructure, QA and statistics. Creating a mirror for each
+repository is required as part of the incubation process.
+
 In order to connect your repository with the mirror webhook you simply have to
 follow these steps:
 


### PR DESCRIPTION
In summary, since we are using GitHub as a promotional tool, we need to keep the marketing message focused - hence we only add FIWARE owned assets under the main FIWARE account.