### PR TITLE
Amend on the CREDITS file rule

### DIFF
--- a/docs/external_contributions.md
+++ b/docs/external_contributions.md
@@ -60,9 +60,13 @@ given by mentors. The contributor's role includes:
     and review.
 
 Credits **MUST** be given to external contributors. A _CREDITS_ file **MUST** be
-present at the root directory of the GE code repository, including one line per
-contributor to the project. An example can be found
-[here](https://github.com/nodejs/node/blob/master/AUTHORS).
+present at the root directory of the GE code repository. The format of that file
+MAY use some of the following alternatives (it's up to GE team to chose which
+option they prefer):
+
+- One line per contributor to the project. An example can be found [here](https://github.com/nodejs/node/blob/master/AUTHORS).
+- Include a link to the contributors graph in the github repository. An example of the contributor graph can be found [here](https://github.com/telefonicaid/fiware-orion/graphs/contributors).
+- A list of contributors and the detail of their particular contributons. An examples can be found [here](https://github.com/sinatra/sinatra/blob/master/AUTHORS.md).
 
 The public **backlog organization** for _Welcome Contributions_ **SHOULD** be as
 follows:

--- a/docs/external_contributions.md
+++ b/docs/external_contributions.md
@@ -61,11 +61,11 @@ given by mentors. The contributor's role includes:
 
 Credits **MUST** be given to external contributors. A _CREDITS_ file **MUST** be
 present at the root directory of the GE code repository. The format of that file
-MAY use some of the following alternatives (it's up to GE team to chose which
+SHOULD use some of the following alternatives (it's up to GE team to chose which
 option they prefer):
 
 - One line per contributor to the project. An example can be found [here](https://github.com/nodejs/node/blob/master/AUTHORS).
-- Include a link to the contributors graph in the github repository. An example of the contributor graph can be found [here](https://github.com/telefonicaid/fiware-orion/graphs/contributors).
+- A short list of major contributors and a link to the contributors graph in the github repository. An example can be found [here](https://github.com/Kotti/Kotti/blob/master/AUTHORS.txt)
 - A list of contributors and the detail of their particular contributons. An examples can be found [here](https://github.com/sinatra/sinatra/blob/master/AUTHORS.md).
 
 The public **backlog organization** for _Welcome Contributions_ **SHOULD** be as


### PR DESCRIPTION
I think this rule wording is too strict and this PR is a proposal to make it more flexible. 

I agree it's a good idea to have authors properly credited so that continues being a MUST. However, the rule shouldn't go beyond that point and the specific details on how to do it should be flexible.

In particular, if we compare file with author names (option 1) vs. file with a link to the github contributors graph (option 2) both approaches provide proper credit (i.e. both list the authors based in their contribution degree). However, if we take into account other factors, one can be prefered over the other.

From a point of view of maintenace and obsolescence, github contributors graph clearly advantages to file with author names. Note that to create and mantain the latter one, it isn't just a matter of executing `git shortlog -nse` and capturing the output into a file. Next you have to clean up the results, which can be costly in long lived repositories. For instance, take into account [`git shortlog -nse` output at Orion repository](https://gist.github.com/fgalan/7f4f287189a8d06e3e1370a10d992348). You cannot use that file directly, you have to manually aggregate entries corresponding to the same person and reorder. And you have to do this each time you want to update the file. On the other side, github contributors graph has zero cost and it's always updated.

The only aspect in which file with author names may advantage to github contributors graph is the case in which you take your code out of github to continue the development in another place. However:

* Is that a realistic posibilty in our case? Specially when FIWARE rules mandate to use github
* Even if that rare case may happen some time in the future, you can (in that moment and not before) edit the CREDITS file and replace the link by an actual list of names.

In fact, the best appoarch is a list of contributors and the detail of their particular contributons (option 3) but it is very costly. It could be feasible if it is done from the very begining when the project starts and the team is very disciplined, but for long lived repository (such as Orion) it will be very hard to provide a file like that. It cannot be directly derived from the list of commits.

Whatever the case, bottom line is that it is up to the GE team to chose which particular format for CREDITS file they prefer.  If some team wants to use a lists with authors, fine with that. If some other team wants to use a link to contributors graph fine also with it. The new wording for the rule would allow that.

(This comes from https://github.com/telefonicaid/iotagent-node-lib/issues/746)