### PR TITLE
Rename CII to OpenSSF

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ of the many tutorials available on the internet.
     [General Requirements](https://fiware-requirements.readthedocs.io/en/latest/GE_Requirements).
 
 -   Every Generic Enabler must sign-up to the
-    [CII Best Practices Badge Program](https://bestpractices.coreinfrastructure.org/en/signup) and display the badge.
+    [OpenSSF Best Practices Badge Program](https://bestpractices.coreinfrastructure.org/en/signup) and display the badge.
 
 -   GitHub and GitHub Issue tracking **MUST** be used.
 

--- a/docs/GE_Checklist.md
+++ b/docs/GE_Checklist.md
@@ -140,7 +140,7 @@ progress on issues will eventually result in the enabler being quarantined or be
 <span style="color:#233c68;">&#x24D5;</span> All of the FIWARE "**MUST**" requirements (marked
 <span style="color:#233c68;">&#x24D5;</span> ) **MUST** be fulfilled before the incubation period is complete.
 
-<span style="color:red">&#x24D2;</span> The CII Best Practices Badge **MUST** be displayed
+<span style="color:red">&#x24D2;</span> The OpenSSF Best Practices Badge **MUST** be displayed
 [![.](https://bestpractices.coreinfrastructure.org/projects/24/badge)](#) and passing.
 
 <span style="color:#233c68;">&#x24D5;</span> The enabler should have demonstrated that it fulfills a real need within

--- a/docs/GE_roadmap_template.md
+++ b/docs/GE_roadmap_template.md
@@ -15,7 +15,7 @@ GitHub repositories `README.md` **MUST** include the following badges at the ver
     License under the component is offered). Example:
     `https://img.shields.io/github/license/telefonicaid/fiware-orion.svg` Example:
     `https://img.shields.io/readthedocs/fiware-orion.svg`
--   [![.](https://bestpractices.coreinfrastructure.org/projects/24/badge)](#) - **CII Best Practices Badge**.
+-   [![.](https://bestpractices.coreinfrastructure.org/projects/24/badge)](#) - **OpenSSF Best Practices Badge**.
 -   [![.](https://img.shields.io/docker/pulls/fiware/orion.svg)](#) - **Docker** (pointer to the Docker container at the
     Docker Hub Repository). Example: `https://img.shields.io/docker/pulls/fiware/orion.svg`
 -   Optional Support badges (e.g. Stack Overflow) - see below.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ practices for its development.
 <span/>
 
 -   Every Generic Enabler must sign-up to the
-    [CII Best Practices Badge Program](https://bestpractices.coreinfrastructure.org/en/signup) and display the badge.
+    [OpenSSF Best Practices Badge Program](https://bestpractices.coreinfrastructure.org/en/signup) and display the badge.
 
 -   Every Generic Enabler **MUST** comply with the
     [Licensing and IPR Management requirements](https://fiware-requirements.readthedocs.io/en/latest/GE_Requirements/#licensing-and-ipr-management)

--- a/docs/project_badges.md
+++ b/docs/project_badges.md
@@ -3,7 +3,7 @@
 <span style="color:#233c68;">&#x24D5;</span> GitHub repositories `README.md` **MUST** include the following badges at
 the very beginning of the document:
 
--   FIWARE Chapter, FLOSS License, CII Best Practices Badge, Documentation, FIWARE Generic Enabler Status.
+-   FIWARE Chapter, FLOSS License, OpenSSF Best Practices Badge, Documentation, FIWARE Generic Enabler Status.
 -   Docker Pulls (where applicable).
 
 <span style="color:#233c68;">&#x24D5;</span> GitHub repositories `README.md` **SHOULD** list either of the following


### PR DESCRIPTION
This PR renames the project name from CII Best Practices Badge to OpenSSF Best Practices Badge.

Reference: 
- https://github.com/coreinfrastructure/best-practices-badge/commit/7ec2b925c3edc60c57b362dc3d369b7db8f2eb69
- https://bestpractices.coreinfrastructure.org/